### PR TITLE
decoder: reset control_time when finalizing decoder

### DIFF
--- a/src/decoder.c
+++ b/src/decoder.c
@@ -1506,6 +1506,7 @@ void arib_finalize_decoder( arib_decoder_t* decoder )
         free( p_region );
     }
     decoder->p_region = NULL;
+    decoder->i_control_time = 0;
 }
 
 size_t arib_decode_buffer( arib_decoder_t* decoder,


### PR DESCRIPTION
This way finalize_decoder() can properly be utilized as a flush
function.

Ref https://github.com/nkoriyama/aribb24/issues/10#issuecomment-462555624