### PR TITLE
decoder: add curly braces around a multi-line statement

### DIFF
--- a/src/decoder.c
+++ b/src/decoder.c
@@ -1140,8 +1140,10 @@ static int decoder_handle_time( arib_decoder_t *decoder )
                 break;
             default:
                 if( i_mode == 1 && c >= 0x40 && c <= 0x7F )
+                {
                     decoder->i_control_time += c & 0x3f;
                     return 1;
+                }
                 return 0;
         }
         if( i_mode == 0 )


### PR DESCRIPTION
It seems like these are meant to be executed together when correct
data is decoded. Right now it would always return one in this
default case.