### PR TITLE
Fixed DRCS parser bug

### DIFF
--- a/src/decoder.c
+++ b/src/decoder.c
@@ -1139,9 +1139,10 @@ static int decoder_handle_time( arib_decoder_t *decoder )
                     return 1;
                 break;
             default:
-                if( i_mode == 1 && c >= 0x40 && c <= 0x7F )
+                if( i_mode == 1 && c >= 0x40 && c <= 0x7F ) {
                     decoder->i_control_time += c & 0x3f;
                     return 1;
+                }
                 return 0;
         }
         if( i_mode == 0 )

--- a/src/drcs.c
+++ b/src/drcs.c
@@ -406,15 +406,19 @@ png_create_write_struct_failed:
 void save_drcs_pattern(
         arib_instance_t *p_instance,
         int i_width, int i_height,
-        int i_depth, const int8_t* p_patternData )
+        int i_depth, const int8_t* p_patternData,
+        int16_t i_CharacterCode )
 {
+//    int i_drcsPage = (i_CharacterCode >> 16) & 0xff;
+    int i_code = (i_CharacterCode & 0xff) - 0x20;
     char* psz_hash = get_drcs_pattern_data_hash( p_instance,
             i_width, i_height, i_depth, p_patternData );
 
-    strncpy( p_instance->p->drcs_hash_table[p_instance->p->i_drcs_num], psz_hash, 32 );
-    p_instance->p->drcs_hash_table[p_instance->p->i_drcs_num][32] = '\0';
+    strncpy( p_instance->p->drcs_hash_table[i_code-1], psz_hash, 32 );
+    p_instance->p->drcs_hash_table[i_code-1][32] = '\0';
 
-    p_instance->p->i_drcs_num++;
+    p_instance->p->i_drcs_num = i_code > p_instance->p->i_drcs_num ?
+                                i_code : p_instance->p->i_drcs_num;
 
     save_drcs_pattern_data_image( p_instance, psz_hash,
             i_width, i_height, i_depth, p_patternData );

--- a/src/drcs.h
+++ b/src/drcs.h
@@ -77,6 +77,6 @@ typedef struct drcs_data_s
 
 bool apply_drcs_conversion_table( arib_instance_t * );
 bool load_drcs_conversion_table( arib_instance_t * );
-void save_drcs_pattern( arib_instance_t *, int, int, int, const int8_t* );
+void save_drcs_pattern( arib_instance_t *, int, int, int, const int8_t*, int16_t );
 
 #endif

--- a/src/parser.c
+++ b/src/parser.c
@@ -79,7 +79,6 @@ static void parse_data_unit_DRCS( arib_parser_t *p_parser, bs_t *p_bs,
                                   uint8_t i_data_unit_parameter,
                                   uint32_t i_data_unit_size )
 {
-    p_parser->p_instance->p->i_drcs_num = 0;
 #ifdef ARIBSUB_GEN_DRCS_DATA
     if( p_parser->p_drcs_data != NULL )
     {
@@ -119,7 +118,7 @@ static void parse_data_unit_DRCS( arib_parser_t *p_parser, bs_t *p_bs,
 
     for( int i = 0; i < i_NumberOfCode; i++ )
     {
-        bs_skip( p_bs, 16 ); /* i_character_code */
+        int16_t i_CharacterCode = bs_read( p_bs, 16 ); /* i_character_code */
         p_parser->i_data_unit_size += 2;
         uint8_t i_NumberOfFont = bs_read( p_bs, 8 );
         p_parser->i_data_unit_size += 1;
@@ -139,7 +138,11 @@ static void parse_data_unit_DRCS( arib_parser_t *p_parser, bs_t *p_bs,
 
         for( int j = 0; j < i_NumberOfFont; j++ )
         {
+#ifdef ARIBSUB_GEN_DRCS_DATA
+            int8_t i_fontId = bs_read( p_bs, 4 ); /* i_fontID */
+#else
             bs_skip( p_bs, 4 ); /* i_fontID */
+#endif //ARIBSUB_GEN_DRCS_DATA
             uint8_t i_mode = bs_read( p_bs, 4 );
             p_parser->i_data_unit_size += 1;
 
@@ -206,18 +209,26 @@ static void parse_data_unit_DRCS( arib_parser_t *p_parser, bs_t *p_bs,
 
 #ifdef ARIBSUB_GEN_DRCS_DATA
                 save_drcs_pattern( p_parser->p_instance, i_width, i_height, i_depth + 2,
-                                   p_drcs_pattern_data->p_patternData );
+                                   p_drcs_pattern_data->p_patternData, i_CharacterCode );
 #else
                 save_drcs_pattern( p_parser->p_instance, i_width, i_height, i_depth + 2,
-                                   p_patternData );
+                                   p_patternData, i_CharacterCode);
                 free( p_patternData );
 #endif //ARIBSUB_GEN_DRCS_DATA
             }
             else
             {
+#ifdef ARIBSUB_GEN_DRCS_DATA
+                int8_t i_regionX = bs_read( p_bs, 8 ); /* i_regionX */
+#else
                 bs_skip( p_bs, 8 ); /* i_regionX */
+#endif //ARIBSUB_GEN_DRCS_DATA
                 p_parser->i_data_unit_size += 1;
+#ifdef ARIBSUB_GEN_DRCS_DATA
+                int8_t i_regionY = bs_read( p_bs, 8 ); /* i_regionY */
+#else
                 bs_skip( p_bs, 8 ); /* i_regionY */
+#endif //ARIBSUB_GEN_DRCS_DATA
                 p_parser->i_data_unit_size += 1;
                 uint16_t i_geometricData_length = bs_read( p_bs, 16 );
                 p_parser->i_data_unit_size += 2;
@@ -245,7 +256,11 @@ static void parse_data_unit_DRCS( arib_parser_t *p_parser, bs_t *p_bs,
 
                 for( int k = 0; k < i_geometricData_length ; k++ )
                 {
+#ifdef ARIBSUB_GEN_DRCS_DATA
+                    int8_t i_geometricData = bs_read( p_bs, 8 ); /* i_geometric_data */
+#else
                     bs_skip( p_bs, 8 ); /* i_geometric_data */
+#endif //ARIBSUB_GEN_DRCS_DATA
                     p_parser->i_data_unit_size += 1;
 
 #ifdef ARIBSUB_GEN_DRCS_DATA
@@ -344,6 +359,8 @@ static void parse_caption_management_data( arib_parser_t *p_parser, bs_t *p_bs )
     p_parser->i_data_unit_size = 0;
     p_parser->i_subtitle_data_size = 0;
     p_parser->psz_subtitle_data = NULL;
+    p_parser->p_instance->p->i_drcs_num = 0;
+    memset(p_parser->p_instance->p->drcs_hash_table, 0, sizeof(p_parser->p_instance->p->drcs_hash_table));
     if( i_data_unit_loop_length > 0 )
     {
         p_parser->psz_subtitle_data = (unsigned char*) calloc(


### PR DESCRIPTION
## DRCSデータのパース不具合
DRCSデータの内容によっては不具合が生じるケースがありました。
"ARIB STD-B24 Table D-1 DRCS structure syntax" の値を例に正常動作するケース、不具合が生じるケースを記載します。

CharacerCodeが0x4121から始まり、抜けなく0x4122, 0x4123, ... のように並んでいるケースでは正常に動作します。

正常ケース1
`
{
"NumberOfCode":1,
"Codes":
[
    {"CharacterCode":0x4121, ...}
]
}
`
正常ケース2
`
{
"NumberOfCode":2,
"Codes":
[
    {"CharacterCode":0x4121, ...},
    {"CharacterCode":0x4122, ...}
]
}
`

一方、CharacterCodeが0x4121以外で始まるか、途中に抜けがあるケースでは正常に動作しません(下駄に変換される)。

正常に動作しないケース1
`
{
"NumberOfCode":1,
"Codes":
[
    {"CharacterCode":0x4122, ...}
]
}
`
正常に動作しないケース2
`
{
"NumberOfCode":2,
"Codes":
[
    {"CharacterCode":0x4121, ...},
    {"CharacterCode":0x4123, ...}
]
}
`
### 修正内容
正常に動作させるためには、CharacerCodeの上位・下位のバイトを見て、ハッシュテーブルに登録する必要があります。
現在のaribb24ライブラリでは、DRCS0-15のページは区別して扱っていないため、ページは無視して下位のバイトのみを見てハッシュテーブルに格納する添字を計算しました。

## DRCSハッシュテーブルの初期化不具合
parse_caption_management_data()からparse_data_unit()が複数回呼ばれるケースでは、parse_data_unit_DRCS()も複数回呼ばれるため、parse_data_unit_DRCS()でp_parser->p_instance->p->i_drcs_num = 0 をすると処理中にハッシュテーブル件数が初期化されてしまいます。

### 修正内容
初期化を parse_data_unit() に移動しました。